### PR TITLE
Adding the childrencourses to the cache

### DIFF
--- a/relation-cache-updater/src/main/scala/org/sunbird/job/relationcache/functions/RelationCacheUpdater.scala
+++ b/relation-cache-updater/src/main/scala/org/sunbird/job/relationcache/functions/RelationCacheUpdater.scala
@@ -69,6 +69,9 @@ class RelationCacheUpdater(config: RelationCacheUpdaterConfig)
                 val unitsMap = getUnitMaps(hierarchy)
                 logger.info("Units cache updating for: "+ unitsMap.size)
                 storeDataInCache("", "", unitsMap, collectionCache)(metrics)
+                val childrenCoursesMap = getOrComposeChildrenCoursesList(hierarchy)
+                storeListDataInCache(rootId, "childrenCourses", childrenCoursesMap, collectionCache)(metrics)
+                logger.info("ChildCourses cache updating for: "+ childrenCoursesMap.size)
                 metrics.incCounter(config.successEventCount)
             } else {
                 logger.warn("Hierarchy Empty: " + rootId)
@@ -193,5 +196,32 @@ class RelationCacheUpdater(config: RelationCacheUpdaterConfig)
                 else Map()) ++ children.flatMap(child => getUnitMaps(child)).toMap
             else Map()
         } else Map()
+    }
+
+    private def getOrComposeChildrenCoursesList(hierarchy: java.util.Map[String, AnyRef]): List[String] = {
+        val children = getChildren(hierarchy).asInstanceOf[java.util.List[java.util.Map[String, AnyRef]]]
+        val resultList = new java.util.ArrayList[String]()
+        val childrenScala = children.asScala.toList
+        for (childrenNode <- childrenScala) {
+            val primaryCategory = childrenNode.get("primaryCategory").asInstanceOf[String]
+            if (List("Course").contains(primaryCategory)) {
+                val courseId = childrenNode.get("identifier").asInstanceOf[String]
+                resultList.add(courseId)
+            }
+        }
+        resultList.asScala.toList
+    }
+
+    private def storeListDataInCache(rootId: String, suffix: String, data: List[String], cache: DataCache)(implicit metrics: Metrics): Unit = {
+        val finalSuffix = Option(suffix).filter(StringUtils.isNotBlank).map(":" + _).getOrElse("")
+        val finalPrefix = Option(rootId).filter(StringUtils.isNotBlank).map(_ + ":").getOrElse("")
+        try {
+            cache.createListWithRetry(finalPrefix + rootId + finalSuffix, data)
+            metrics.incCounter(config.cacheWrite)
+        } catch {
+            case e: Throwable => metrics.incCounter(config.failedEventCount)
+                logger.info(s"Failed to write data for $suffix: $rootId with prefix: $finalPrefix and data: $data")
+                throw e
+        }
     }
 }


### PR DESCRIPTION
1.getOrComposeChildrenCoursesList() -> Added a private method which will return the Map[String, List[String]] where the key is the identifer/courseId and value is the list of children courseIds. 2.To get the children data out of the hierarchy we have a custom or predefined method getChildren() already implemented. 3.getOrComposeChildrenCoursesList()-> is returning Map[String, List[String]] since the storeDataInCache() expects the data in that format.

