### PR TITLE
KB-4212 | Avoid Auto batch creation for Invite-Only Assessment from P…

### DIFF
--- a/post-publish-processor/src/main/scala/org/sunbird/job/postpublish/helpers/BatchCreation.scala
+++ b/post-publish-processor/src/main/scala/org/sunbird/job/postpublish/helpers/BatchCreation.scala
@@ -69,7 +69,14 @@ trait BatchCreation {
       val trackableObj = JSONUtil.deserialize[java.util.Map[String, AnyRef]](trackableStr)
       val trackingEnabled = trackableObj.getOrDefault("enabled", "No").asInstanceOf[String]
       val autoBatchCreateEnabled = trackableObj.getOrDefault("autoBatch", "No").asInstanceOf[String]
-      val trackable = (StringUtils.equalsIgnoreCase(trackingEnabled, "Yes") && StringUtils.equalsIgnoreCase(autoBatchCreateEnabled, "Yes"))
+      var trackable = (StringUtils.equalsIgnoreCase(trackingEnabled, "Yes") && StringUtils.equalsIgnoreCase(autoBatchCreateEnabled, "Yes"))
+      val courseCategory = metadata.getOrDefault("courseCategory", "").asInstanceOf[String]
+      if (trackable) {
+        if (StringUtils.containsIgnoreCase(courseCategory, "Invite-Only")) {
+          trackable = false
+          logger.info("CourseCategory for " + identifier + " : " + courseCategory + ", setting trackable to false")
+        }
+      }
       logger.info("Trackable for " + identifier + " : " + trackable)
       trackable
     } else {


### PR DESCRIPTION
…ost Publish Flink Job (#61)

* KB-4212 | Avoid Auto batch creation for Invite-Only Assessment from Post Publish Flink Job

1. Added logic to skip autoBatch Creation while creating invite only assessment.

* KB-4212 | Avoid Auto batch creation for Invite-Only Assessment from Post Publish Flink Job

1. Added log

* KB-4212 | Avoid Auto batch creation for Invite-Only Assessment from Post Publish Flink Job

1 Added log

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules