### PR TITLE
KB-5880 | Content creator cant see the details when clicked on  Edit live Assessment

### DIFF
--- a/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/publish/helpers/QuestionSetPublisher.scala
+++ b/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/publish/helpers/QuestionSetPublisher.scala
@@ -158,7 +158,7 @@ trait QuestionSetPublisher extends ObjectReader with ObjectValidator with Object
 
 	override def enrichObjectMetadata(obj: ObjectData)(implicit neo4JUtil: Neo4JUtil, cassandraUtil: CassandraUtil, readerConfig: ExtDataConfig, cloudStorageUtil: CloudStorageUtil, config: PublishConfig, definitionCache: DefinitionCache, definitionConfig: DefinitionConfig): Option[ObjectData] = {
 		val newMetadata: Map[String, AnyRef] = obj.metadata ++ Map("pkgVersion" -> (obj.pkgVersion + 1).asInstanceOf[AnyRef], "lastPublishedOn" -> getTimeStamp,
-			"publishError" -> null, "variants" -> null, "downloadUrl" -> null, "compatibilityLevel" -> 5.asInstanceOf[AnyRef], "status" -> "Live")
+			"publishError" -> null, "variants" -> null, "downloadUrl" -> null, "compatibilityLevel" -> obj.metadata.getOrElse("compatibilityLevel", 5.asInstanceOf[AnyRef]), "status" -> "Live")
 		val children: List[Map[String, AnyRef]] = obj.hierarchy.getOrElse(Map()).getOrElse("children", List()).asInstanceOf[List[Map[String, AnyRef]]]
 		Some(new ObjectData(obj.identifier, newMetadata, obj.extData, hierarchy = Some(Map("identifier" -> obj.identifier, "children" -> enrichChildren(children)))))
 	}


### PR DESCRIPTION

1. Hardcoded value of the compatibility level is removed.
